### PR TITLE
\setdigitfont command is deprecated 

### DIFF
--- a/styles/common.tex
+++ b/styles/common.tex
@@ -44,7 +44,7 @@ ItalicFont=XB NiloofarIt,
 BoldItalicFont=XB NiloofarBdIt
 ]{XB Niloofar}
 
-\setdigitfont[
+\setmathdigitfont[
 Scale=1.09,
 Extension=.ttf, 
 Path=styles/fonts/,


### PR DESCRIPTION
\setdigitfont command is deprecated and it is changed to \setmathdigitfont.