### PR TITLE
Fix compilation errors on TeX Live 2025

### DIFF
--- a/bibs/bibs.tex
+++ b/bibs/bibs.tex
@@ -9,7 +9,7 @@
 
 \begin{latin}
 \baselineskip=.8\baselineskip
-\bibliographystyle{./styles/packages/unsrtabbrv}
+\bibliographystyle{../styles/packages/unsrtabbrv}
 
 % Uncomment next line to include uncited references
 % \nocite{*}

--- a/styles/common.tex
+++ b/styles/common.tex
@@ -16,7 +16,7 @@
 
 \usepackage{algorithmicx,algorithm}
 
-\usepackage[localise=on,extrafootnotefeatures]{xepersian}
+\usepackage[localize=on,extrafootnotefeatures]{xepersian}
 \usepackage[noend]{algpseudocode}
 \input{styles/alg-fa}
 


### PR DESCRIPTION
The `localise` option has been renamed to `localize` in newer versions of the xepersian package (see [here](https://qa.parsilatex.com/39312/%D8%AA%D8%BA%DB%8C%DB%8C%D8%B1%DB%8C-%D8%AF%D8%B1-%D9%86%D8%B3%D8%AE%D9%87-%D8%A8%D8%B3%D8%AA%D9%87-bidi-%D9%86%D8%B3%D8%AE%D9%87-25-%D8%A8%D8%B3%D8%AA%D9%87-xepersian-%D9%88%D8%AC%D9%88%D8%AF-%D8%AF%D8%A7%D8%B1%D8%AF%D8%9F-%D9%85%D9%87%D9%85)). This pull request updates the option name accordingly to ensure compatibility with recent package versions and to prevent compilation errors such as: `Unknown option 'localise' for package bidi`.

Also fixed the relative path to the `unsrtabbrv.bst` file, which was causing a compilation error in newer versions of TeX Live.


