### PR TITLE
Fix Bibliography title issue

### DIFF
--- a/styles/common.tex
+++ b/styles/common.tex
@@ -112,7 +112,7 @@ BoldFont=Sharif1.3-SemiBold,
 
 \renewcommand{\listfigurename}{فهرست شکل‌ها}
 \renewcommand{\listtablename}{فهرست جدول‌ها}
-\renewcommand{\bibname}{\rl{{مراجع}\hfill}} 
+
 
 
 % -------------------- Commands --------------------

--- a/thesis.tex
+++ b/thesis.tex
@@ -19,6 +19,8 @@
 \input{styles/custom.tex}
 
 \begin{document}
+	
+\renewcommand{\bibname}{\rl{{مراجع}\hfill}} 
 
 
 % -------------------- Font Settings --------------------


### PR DESCRIPTION
XePersian appears to ignore \renewcommand{\bibname}{...} when it is placed before \begin{document}; therefore, the command is now moved to after \begin{document}.